### PR TITLE
docs: add Next.js/server side rendering information

### DIFF
--- a/docs/web-sdk.md
+++ b/docs/web-sdk.md
@@ -61,29 +61,6 @@ And then loaded in your JavaScript and bundled as you like:
 import '@exmg/livery';
 ```
 
-#### Using with Next.js
-Next.js makes use of server side rendering, which the Livery Web SDK does not currently support. However, users of Next.js can still use the SDK by making use of Next.js’s support for [dynamic imports](https://nextjs.org/docs/advanced-features/dynamic-import), which ensure the module being imported is evaluated at runtime on the client. The code below illustrates basic usage with Next.js. 
-
-```javascript
-// do not import('@exmg/livery') here
-
-function MyComponent() {
- useEffect(
-   () => {
-     import('@exmg/livery')
-   },
-   [] // tell react to only use this effect on mount
- )
- return (
-   <livery-player
-     streamid="5ddb98f5e4b0937e6a4507f2"
-     style="width: 100%; height: 50vh;"
-   ></livery-player>
- )
-}
-```
-
-
 ## Usage
 
 ### HTML
@@ -296,3 +273,27 @@ Dispatched with event type: `'livery-volume-change'` when `volume` and/or `muted
 | -------- | --------- | ------------------------------------------------- |
 | `muted`  | `boolean` | If `true` then audio is muted.                    |
 | `volume` | `number`  | Audio volume, from 0.0 (silent) to 1.0 (loudest). |
+
+## Integrations
+
+### Next.js
+Next.js makes use of server side rendering, which the Livery Web SDK does not currently support. However, users of Next.js can still use the SDK by making use of Next.js’s support for [dynamic imports](https://nextjs.org/docs/advanced-features/dynamic-import), which ensure the module being imported is evaluated at runtime on the client. The code below illustrates basic usage with Next.js. 
+
+```javascript
+// do not import('@exmg/livery') here
+
+function MyComponent() {
+ useEffect(
+   () => {
+     import('@exmg/livery')
+   },
+   [] // tell react to only use this effect on mount
+ )
+ return (
+   <livery-player
+     streamid="5ddb98f5e4b0937e6a4507f2"
+     style="width: 100%; height: 50vh;"
+   ></livery-player>
+ )
+}
+```

--- a/docs/web-sdk.md
+++ b/docs/web-sdk.md
@@ -61,6 +61,29 @@ And then loaded in your JavaScript and bundled as you like:
 import '@exmg/livery';
 ```
 
+#### Using with Next.js
+Next.js makes use of server side rendering, which the Livery Web SDK does not currently support. However, users of Next.js can still use the SDK by making use of Next.js’s support for [dynamic imports](https://nextjs.org/docs/advanced-features/dynamic-import), which ensure the module being imported is evaluated at runtime on the client. The code below illustrates basic usage with Next.js. 
+
+```javascript
+// do not import('@exmg/livery') here
+
+function MyComponent() {
+ useEffect(
+   () => {
+     import('@exmg/livery')
+   },
+   [] // tell react to only use this effect on mount
+ )
+ return (
+   <livery-player
+     streamid="5ddb98f5e4b0937e6a4507f2"
+     style="width: 100%; height: 50vh;"
+   ></livery-player>
+ )
+}
+```
+
+
 ## Usage
 
 ### HTML

--- a/docs/web-sdk.md
+++ b/docs/web-sdk.md
@@ -277,7 +277,9 @@ Dispatched with event type: `'livery-volume-change'` when `volume` and/or `muted
 ## Integrations
 
 ### Next.js
-Next.js makes use of server side rendering, which the Livery Web SDK does not currently support. However, users of Next.js can still use the SDK by making use of Next.js’s support for [dynamic imports](https://nextjs.org/docs/advanced-features/dynamic-import), which ensure the module being imported is evaluated at runtime on the client. The code below illustrates basic usage with Next.js. 
+Next.js makes use of server side rendering, which the Livery Web SDK does not currently support. However, users of Next.js can still use the SDK by making use of Next.js’s support for [dynamic imports](https://nextjs.org/docs/advanced-features/dynamic-import) inside a [React Effect Hook](https://reactjs.org/docs/hooks-effect.html) or in a [React class component's `componentDidMount` lifecycle method](https://reactjs.org/docs/react-component.html#componentdidmount). When used in combination, this ensures the module being imported is evaluated at runtime on the client.
+
+Note that many of the examples that Next.js provides use a statement of the form `dynamic( import(...) )`. The `dynamic()` function is used for importing React components and is not used for importing `@exmg/livery`. The code below illustrates basic usage with Next.js. 
 
 ```javascript
 // do not import('@exmg/livery') here


### PR DESCRIPTION
Adds a note advising users of Node.js how to import the Livery Web SDK without permitting Node.js to attempt rendering it on the server side. The commit provides a code sample showing a basic usage example that has been tested as functional on an app created with create-next-app